### PR TITLE
fixed terms and conditions link in upgrade account

### DIFF
--- a/src/upgrade/UpgradeCard.js
+++ b/src/upgrade/UpgradeCard.js
@@ -137,6 +137,8 @@ export default class UpgradeCard extends PureComponent {
 			phone, termsAndConditions, progress, serverError, validatedOnce, statesList } = this.state;
 		const { residenceList } = this.props;
 
+		const linkToTermsAndConditions = 'https://www.binary.com/' + ((JSON.parse(localStorage.getItem('boot')).language).toLowerCase() || 'en') + '/terms-and-conditions.html';
+
 		const firstNameIsValid = firstName.length >= 2;
 		const lastNameIsValid = lastName.length >= 2;
 		const residenceIsValid = residence.length > 0;
@@ -280,7 +282,7 @@ export default class UpgradeCard extends PureComponent {
 								onClick={this.onTermsAndConditionsChanged}
 							/>
 							<M m="I agree to the" />&nbsp;
-							<a href="https://binary.com/terms-and-conditions" target="_blank" rel="noopener noreferrer">
+							<a href={linkToTermsAndConditions} target="_blank" rel="noopener noreferrer">
 								<M m="terms and conditions" />
 							</a>
 						</label>


### PR DESCRIPTION
The link of terms and conditions in upgrade account page now works, and also it redirects to the binary.com with the same language user is using the next-gen app